### PR TITLE
 Add support for TPS546D24S as a drop in replacement for the TPS546D24A

### DIFF
--- a/main/TPS546.c
+++ b/main/TPS546.c
@@ -22,8 +22,9 @@
 
 static const char *TAG = "TPS546.c";
 
-static uint8_t DEVICE_ID1[] = {0x54, 0x49, 0x54, 0x6B, 0x24, 0x41};
-static uint8_t DEVICE_ID2[] = {0x54, 0x49, 0x54, 0x6D, 0x24, 0x41};
+static uint8_t DEVICE_ID1[] = {0x54, 0x49, 0x54, 0x6B, 0x24, 0x41}; // TPS546D24A
+static uint8_t DEVICE_ID2[] = {0x54, 0x49, 0x54, 0x6D, 0x24, 0x41}; // TPS546D24A
+static uint8_t DEVICE_ID3[] = {0x54, 0x49, 0x54, 0x6D, 0x24, 0x62}; // TPS546D24S
 static uint8_t MFR_ID[] = {'B', 'A', 'X'};
 static uint8_t MFR_MODEL[] = {'H', 'E', 'X'};
 static uint8_t MFR_REVISION[] = {0x00, 0x00, 0x01};
@@ -374,8 +375,8 @@ int TPS546_init(void)
     smb_read_block(PMBUS_IC_DEVICE_ID, data, 6);
     ESP_LOGI(TAG, "Device ID: %02x %02x %02x %02x %02x %02x", data[0], data[1],
                  data[2], data[3], data[4], data[5]);
-    /* There's two different known device IDs observed so far */
-    if ( (memcmp(data, DEVICE_ID1, 6) != 0) && (memcmp(data, DEVICE_ID2, 6) != 0) )
+    /* There's 3 different known device IDs observed so far */
+    if ( (memcmp(data, DEVICE_ID1, 6) != 0) && (memcmp(data, DEVICE_ID2, 6) != 0) && (memcmp(data, DEVICE_ID3, 6) != 0))
     {
         ESP_LOGI(TAG, "ERROR- cannot find TPS546 regulator");
         return -1;


### PR DESCRIPTION
    by just registering the device ID properly, everything else works as
    expected.